### PR TITLE
DFOP e PHTG - Atividade 6 (correção)

### DIFF
--- a/test/cucumber/steps/NewsSteps.groovy
+++ b/test/cucumber/steps/NewsSteps.groovy
@@ -192,6 +192,11 @@ Then(~'^I can fill the news details$') { ->
     page.fillNewDetails("essa eh a descricao")
     page.clickOnCreate()
     assert NewsTestDataAndOperations.checkExistingNewsByDescription("essa eh a descricao")
+
+    // eh necessario deletar a news criada para posteriormente efetuar o teste de Reports
+    at NewsShowPage
+    page.remove()
+
 }
 
 When(~'^I try to create a news with description "([^"]*)" and date "([^"]*)" for "([^"]*)" research group$') { String description, String date, String group ->


### PR DESCRIPTION
Dentro do cenário "new news web", removendo a news após ter sido criada para o teste de reports funcionar.
